### PR TITLE
feat: add SPADE down blocks, mid attention and EMA weights

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -145,6 +145,29 @@ class ResBlock(nn.Module):
         return self.skip(x) + h
 
 
+class AttentionBlock(nn.Module):
+    def __init__(self, channels, num_heads=4):
+        super().__init__()
+        self.num_heads = num_heads
+        self.norm = nn.GroupNorm(32, channels)
+        self.qkv = nn.Conv2d(channels, channels * 3, 1)
+        self.proj_out = nn.Conv2d(channels, channels, 1)
+
+    def forward(self, x):
+        b, c, h, w = x.shape
+        qkv = self.qkv(self.norm(x))
+        q, k, v = qkv.chunk(3, dim=1)
+        q = q.reshape(b, self.num_heads, c // self.num_heads, h * w).permute(0, 1, 3, 2)
+        k = k.reshape(b, self.num_heads, c // self.num_heads, h * w).permute(0, 1, 3, 2)
+        v = v.reshape(b, self.num_heads, c // self.num_heads, h * w).permute(0, 1, 3, 2)
+        attn = torch.matmul(q, k.transpose(-1, -2)) * (c // self.num_heads) ** -0.5
+        attn = attn.softmax(dim=-1)
+        out = torch.matmul(attn, v)
+        out = out.permute(0, 1, 3, 2).reshape(b, c, h, w)
+        out = self.proj_out(out)
+        return x + out
+
+
 class SDMUNet(nn.Module):
     """
     diffusers互換のSDM UNet:
@@ -172,17 +195,35 @@ class SDMUNet(nn.Module):
         ch = base_channels
         emb_ch = base_channels * 4
 
-        # Down
+        # Down (SPADE)
         self.down_blocks = nn.ModuleList()
         self.down_chs = [ch]
         for i, mult in enumerate(channel_mult):
             out_ch = base_channels * mult
             for _ in range(num_res_blocks):
-                self.down_blocks.append(ResBlock(ch, emb_ch, out_ch, dropout))
+                self.down_blocks.append(
+                    SDMResBlock(
+                        ch,
+                        emb_ch,
+                        out_channels=out_ch,
+                        c_channels=num_classes,
+                        dropout=dropout,
+                        use_scale_shift_norm=use_scale_shift_norm,
+                    )
+                )
                 ch = out_ch
                 self.down_chs.append(ch)
             if i != len(channel_mult) - 1:
-                self.down_blocks.append(ResBlock(ch, emb_ch, ch, dropout, down=True))
+                self.down_blocks.append(
+                    SDMResBlock(
+                        ch,
+                        emb_ch,
+                        c_channels=num_classes,
+                        dropout=dropout,
+                        use_scale_shift_norm=use_scale_shift_norm,
+                        down=True,
+                    )
+                )
                 self.down_chs.append(ch)
 
         # Middle (SPADE)
@@ -193,6 +234,7 @@ class SDMUNet(nn.Module):
             dropout=dropout,
             use_scale_shift_norm=use_scale_shift_norm,
         )
+        self.mid_attn = AttentionBlock(ch)
         self.mid_block2 = SDMResBlock(
             ch,
             emb_ch,
@@ -248,24 +290,18 @@ class SDMUNet(nn.Module):
         h = self.in_conv(x)
         skips = [h]
         for blk in self.down_blocks:
-            if isinstance(blk, ResBlock):
-                h = blk(h, emb)
-            else:
-                h = blk(h, emb)  # no seg in down
+            h = blk(h, self._downseg(seg, h), emb)
             skips.append(h)
 
         h = self.mid_block1(h, self._downseg(seg, h), emb)
+        h = self.mid_attn(h)
         h = self.mid_block2(h, self._downseg(seg, h), emb)
 
         for blk in self.up_blocks:
-            if isinstance(blk, SDMResBlock):
-                if "SDMResBlock" in blk.__class__.__name__ and blk.up is False:
-                    # concat skip
-                    skip = skips.pop()
-                    h = torch.cat([h, skip], dim=1)
-                h = blk(h, self._downseg(seg, h), emb)
-            else:
-                h = blk(h, emb)
+            if blk.up is False:
+                skip = skips.pop()
+                h = torch.cat([h, skip], dim=1)
+            h = blk(h, self._downseg(seg, h), emb)
 
         h = self.out_norm(h)
         h = self.out_act(h)

--- a/train.py
+++ b/train.py
@@ -1,4 +1,5 @@
 import argparse
+import copy
 from pathlib import Path
 
 import torch
@@ -10,6 +11,16 @@ from tqdm import tqdm
 
 from src.data import SDMDataset
 from src.model import SDMUNet
+
+
+def update_ema(ema_model: torch.nn.Module, model: torch.nn.Module, decay: float) -> None:
+    """Update exponential moving average of model weights."""
+    ema_params = dict(ema_model.named_parameters())
+    model_params = dict(model.named_parameters())
+    for name, param in model_params.items():
+        ema_params[name].data.mul_(decay).add_(param.data, alpha=1 - decay)
+    for ema_buf, buf in zip(ema_model.buffers(), model.buffers()):
+        ema_buf.copy_(buf)
 
 
 def main(args):
@@ -56,6 +67,11 @@ def main(args):
         use_scale_shift_norm=True,
     ).to(device)
 
+    ema_unet = copy.deepcopy(unet).to(device)
+    ema_unet.eval()
+    for p in ema_unet.parameters():
+        p.requires_grad_(False)
+
     opt = torch.optim.AdamW(unet.parameters(), lr=args.lr)
     noise_scheduler = DDPMScheduler(1000, beta_schedule="squaredcos_cap_v2")
     use_autocast = device.type == "cuda" and prec in ["fp16", "bf16"]
@@ -93,10 +109,11 @@ def main(args):
                 torch.nn.utils.clip_grad_norm_(unet.parameters(), 1.0)
                 opt.step()
 
+            update_ema(ema_unet, unet, args.ema_decay)
             pbar.set_description_str(f"Epoch[{epoch:06d}] loss {loss.item():.4f}")
 
         # サンプル出力
-        unet.eval()
+        ema_unet.eval()
         with (
             torch.no_grad(),
             autocast(device_type=device.type, dtype=amp_dtype, enabled=use_autocast),
@@ -108,7 +125,7 @@ def main(args):
                 noise_scheduler.config.num_train_timesteps - 1, -1, -1, device=device
             )
             for tt in timesteps:
-                pred = unet(x, tt.expand(b), seg_vis)
+                pred = ema_unet(x, tt.expand(b), seg_vis)
                 x = noise_scheduler.step(pred, tt, x).prev_sample
             imgs = (x.clamp(-1, 1) + 1) / 2
             save_image(imgs, out_dir / f"sample/sample_epoch{epoch:06d}.png", nrow=2)
@@ -116,7 +133,9 @@ def main(args):
         # 指定エポック毎にモデル保存
         if epoch % args.log_every == 0:
             torch.save(unet.state_dict(), out_dir / f"unet_sdm_epoch{epoch:06d}.pt")
+            torch.save(ema_unet.state_dict(), out_dir / f"unet_sdm_ema_epoch{epoch:06d}.pt")
         unet.train()
+        ema_unet.eval()
 
     print("done.")
 
@@ -137,5 +156,6 @@ if __name__ == "__main__":
     p.add_argument("--log_every", type=int, default=1)
     p.add_argument("--seed", type=int, default=42)
     p.add_argument("--precision", choices=["fp32", "fp16", "bf16"], default="bf16")
+    p.add_argument("--ema_decay", type=float, default=0.999, help="EMA decay rate")
     args = p.parse_args()
     main(args)


### PR DESCRIPTION
## Summary
- condition down blocks with SPADE to inject semantic labels
- insert a self-attention block in the UNet middle stage
- track model weights with EMA for stabler sampling

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68974dd669848325b2510d64206ef85a